### PR TITLE
Add option to force-import pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ zfs_pools:  #defines zpool(s) to manage
       - 'ata-INTEL_SSDSC2BW240A4_CVDA4010011R2403GN'
     type: 'raidz2'  #define pool type... | basic (no-raid) | mirror | raidz | raidz2 | raidz3
     state: 'present'
+#    force_import: true
   - name: 'SSD-TANK'
     action: 'add'
     compression: 'lz4'  # on | off (default) | lzjb | gzip | gzip-1 | gzip-2 | gzip-3 | gzip-4 | gzip-5 | gzip-6 | gzip-7 | gzip-8 | gzip-9 | lz4 | zle

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -117,6 +117,7 @@ zfs_pools: []
   #   # Define pool type... | basic (no-raid) | mirror | raidz | raidz2 | raidz3
   #   type: mirror
   #   state: present
+  #   # force_import: true
   #   # override global scrub cron job parameters per zpool
   #   scrub_cron:
   #     # enable: False  # disable scrub cron job creation for this specific zpool

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -1,4 +1,13 @@
 ---
+
+- name: manage_fs | force-importing existing zpools
+  command: "zpool import -f {{ item.name }}"
+  with_items: "{{ zfs_pools }}"
+  when: >
+        zfs_pools is defined and
+        item.force_import
+  ignore_errors: yes
+
 - name: manage_zfs | checking existing zpool(s)
   shell: "zpool list | awk 'FNR >1' | awk '{print $1}'"
   changed_when: false


### PR DESCRIPTION
When bringing up a brand new ec2 instance connected to persistent ebs
storage, we need the option to force-import the zpool instead of
attempting, and failing, to re-create it